### PR TITLE
Add maven site dependency to wagon webdav

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <plugins.maven-plugin-plugin.version>3.4</plugins.maven-plugin-plugin.version>
 
         <plugins.maven.wagon.version>2.10</plugins.maven.wagon.version>
+        <plugins.maven.wagon-webdav.version>2.10</plugins.maven.wagon-webdav.version>
         <plugins.maven.war.version>2.6</plugins.maven.war.version>
         <plugins.versions.version>2.2</plugins.versions.version>
         <plugins.maven.shade.version>2.4.3</plugins.maven.shade.version>
@@ -364,6 +365,11 @@
                             <groupId>org.apache.maven.wagon</groupId>
                             <artifactId>wagon-ssh</artifactId>
                             <version>${plugins.maven.wagon.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.maven.wagon</groupId>
+                            <artifactId>wagon-webdav-jackrabbit</artifactId>
+                            <version>${plugins.maven.wagon-webdav.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Add maven site dependency to wagon webdav so to enable the upload of the generated site to artifactory.