### PR TITLE
maven-war-plugin: disable add library to classpath by *default*

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,6 @@
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                         <archive>
                             <manifest>
-                                <addClasspath>true</addClasspath>
                                 <addDefaultImplementationEntries>true
                                 </addDefaultImplementationEntries>
                                 <addDefaultSpecificationEntries>true


### PR DESCRIPTION
This avoids the situation where all your libraries in WEB-INF/lib are
duplicated in MANIFEST.MF

Note that if any project produces 'optional' libraries and needs them
appended to the classpath they will need to follow:
https://maven.apache.org/plugins/maven-war-plugin/examples/war-manifest-guide.html