### PR TITLE
Add pitest profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
         <plugins.maven.surefire.version>2.20</plugins.maven.surefire.version>
         <plugins.maven.failsafe.version>${plugins.maven.surefire.version}</plugins.maven.failsafe.version>
         <plugins.maven.processor.version>3.3.1</plugins.maven.processor.version>
+        <plugins.pitest.version>1.2.4</plugins.pitest.version>
+        <pitest.enabled>false</pitest.enabled>
 
         <!-- Javadoc links to Java APIs -->
         <javadoc.java.link>http://download.oracle.com/javase/${java.se.version}/docs/api/
@@ -493,7 +495,28 @@
                         </dependency>
                     </dependencies>
                 </plugin>
-
+                <plugin>
+                    <groupId>org.pitest</groupId>
+                    <artifactId>pitest-maven</artifactId>
+                    <version>${plugins.pitest.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>mutationCoverage</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <failWhenNoMutations>false</failWhenNoMutations>
+                        <threads>5</threads>
+                        <excludedClasses>
+                            <!-- Exclude integration tests -->
+                            <!-- TODO: review this pattern -->
+                            <excludedClass>*IT</excludedClass>
+                        </excludedClasses>
+                    </configuration>
+                </plugin>
             </plugins>
 
         </pluginManagement>
@@ -727,6 +750,23 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+          <id>pitest</id>
+          <activation>
+            <property>
+              <name>pitest.enabled</name>
+              <value>true</value>
+            </property>
+          </activation>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+              </plugin>
+            </plugins>
+          </build>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -753,21 +753,21 @@
             </build>
         </profile>
         <profile>
-          <id>pitest</id>
-          <activation>
-            <property>
-              <name>pitest.enabled</name>
-              <value>true</value>
-            </property>
-          </activation>
-          <build>
-            <plugins>
-              <plugin>
-                <groupId>org.pitest</groupId>
-                <artifactId>pitest-maven</artifactId>
-              </plugin>
-            </plugins>
-          </build>
+            <id>pitest</id>
+            <activation>
+                <property>
+                    <name>pitest.enabled</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -508,6 +508,7 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <mutationThreshold>0</mutationThreshold>
                         <failWhenNoMutations>false</failWhenNoMutations>
                         <threads>5</threads>
                         <excludedClasses>


### PR DESCRIPTION
* The profile is by default disabled
* It's activated by setting property `pitest.enabled` to `true`
* Activating this profile will run mutation coverage as part of `test` goal.
