### PR TITLE
Framework E (17.104.x): Java 21 / WildFly 32 / Jakarta EE 10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [21.0.0-SNAPSHOT] - 2026-03-26
+### Changed
+- Upgraded minimum Java version requirement from 17 to 21 (`enforcer.java.version.range`, `java.major.version`)
+- Updated Jakarta EE version properties: `java.ee.version` to `10`, `javaee-api.version` to `10.0.0`
+- Replaced `javax.xml.bind:jaxb-api` with `jakarta.xml.bind:jakarta.xml.bind-api` in `coveralls-maven-plugin` dependency
+- Updated `maven-plugin-plugin` from `3.7.1` to `3.9.0`
+- Added `WEB-INF/lib/resteasy-*.jar` to `maven-war-plugin` `<packagingExcludes>` — prevents bundled RESTEasy JARs from conflicting with WildFly's own RESTEasy module when deploying without `web.xml`
+
 ## [17.103.0] - 2025-07-11
 ### Changed
 - Github migration to HMCTS Organisation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,52 @@
-# Parent POM
+# cp-maven-parent-pom
 
-The parent Maven POM for all Common Platform open source projects. This allows the definition of
-common Maven configuration that should be consistent across all open source projects.
+`uk.gov.justice:maven-parent-pom`
+
+The root Maven parent POM for all Criminal Practice Platform (CPP) framework projects. It establishes the baseline build configuration inherited by every framework and platform project.
+
+## Position in the hierarchy
+
+```
+maven-super-pom  (external)
+└── maven-parent-pom  ← this project
+    ├── maven-common-bom
+    └── maven-framework-parent-pom
+        └── ...
+```
+
+`cpp-platform-maven-parent-pom` also inherits directly from `maven-super-pom`, making both tracks siblings at the root.
+
+## What this POM provides
+
+**Java / Jakarta EE target**
+- Java 21 (`<release>21</release>`)
+- Jakarta EE 10
+- Enforcer requires Java ≥ 21 and Maven ≥ 3.3.9
+
+**Plugin management** (versions pinned for all inheriting projects)
+- `maven-compiler-plugin` 3.10.1 — Java 21, full warnings + lint enabled
+- `maven-surefire-plugin` / `maven-failsafe-plugin` 3.1.2
+- `jacoco-maven-plugin` 0.8.12 — coverage agent wired to all test and integration-test phases
+- `maven-jar-plugin` 3.0.2 — SCM and CI metadata stamped into every JAR manifest
+- `maven-war-plugin` 3.1.0 — resteasy JARs excluded from WAR (provided by WildFly)
+- `maven-enforcer-plugin` 3.0.0-M3 — Java version, Maven version, and plugin-version rules active by default
+- `maven-dependency-plugin`, `maven-resources-plugin`, `maven-assembly-plugin`, `maven-source-plugin`, `maven-javadoc-plugin`, `buildnumber-maven-plugin`, `build-helper-maven-plugin`, `versions-maven-plugin`, `pitest-maven`, `sonar-maven-plugin`
+
+**Profiles**
+| Profile | Activation | Effect |
+|---|---|---|
+| `raml-jar` | `src/raml` directory exists | Packages `src/raml/**` into a `raml` classifier JAR |
+| `release` | `-Prelease` | Attaches sources and Javadocs |
+| `pitest` | `-Dpitest.enabled=true` | Runs PIT mutation testing |
+| `java-ee-7` | `java.ee.version=7` | Sets legacy EJB version (compatibility shim) |
+| `windows` / `unix` | OS | Populates `ci.buildNode` from `%COMPUTERNAME%` or `$HOSTNAME` |
+
+**Build conventions**
+- `src/raml/json` is copied to `target/generated-test-resources/json`
+- `src/raml/json/schema` is copied to `target/generated-resources/json/schema`
+
+## Usage
+
+All framework projects (`cp-framework-libraries`, `cp-microservice-framework`, `cp-event-store`, `cp-cake-shop`) inherit from `maven-framework-parent-pom` which in turn inherits from this POM. Service context projects (`cpp-context-*`) inherit via the `cpp-platform-*` hierarchy which also traces back here through `maven-super-pom`.
+
+Do not declare this as a direct parent unless building a new top-level framework project.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals centos8-j17-postgres
+    - identifier -equals ubuntu-j21
  
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -7,26 +7,29 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>17.0.0</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>maven-parent-pom</artifactId>
-    <version>17.103.1-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
+        <!-- Default argLine - can be overridden by JaCoCo or other agents -->
+        <argLine></argLine>
+
         <!-- Minimum version of Maven required to build the project -->
         <maven.minimum.version>3.3.9</maven.minimum.version>
 
         <!-- Enforcer settings - ranges need to be in the format defined at http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html -->
         <enforcer.maven.version.range>[${maven.minimum.version},)</enforcer.maven.version.range>
-        <enforcer.java.version.range>[17,)</enforcer.java.version.range>
+        <enforcer.java.version.range>[21,)</enforcer.java.version.range>
 
 
         <!-- Java API versions targeted -->
-        <java.major.version>17</java.major.version>
-        <java.ee.version>8</java.ee.version>
-        <javaee-api.version>8.0.1</javaee-api.version>
+        <java.major.version>21</java.major.version>
+        <java.ee.version>10</java.ee.version>
+        <javaee-api.version>10.0.0</javaee-api.version>
 
         <!-- Compilation properties -->
         <compiler.debug>true</compiler.debug>
@@ -51,7 +54,7 @@
         <plugins.maven.site.version>3.6</plugins.maven.site.version>
         <plugins.maven.javadoc.version>2.10.4</plugins.maven.javadoc.version>
         <plugins.maven.source.version>3.0.1</plugins.maven.source.version>
-        <plugins.maven-plugin-plugin.version>3.7.1</plugins.maven-plugin-plugin.version>
+        <plugins.maven-plugin-plugin.version>3.9.0</plugins.maven-plugin-plugin.version>
 
         <plugins.maven.wagon.version>2.10</plugins.maven.wagon.version>
         <plugins.maven.war.version>3.1.0</plugins.maven.war.version>
@@ -77,7 +80,7 @@
         </javadoc.javaee.link>
         <javadoc.javamail.link>http://javamail.kenai.com/nonav/javadocs/</javadoc.javamail.link>
 
-        <plugins.jacoco.version>0.8.8</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.12</plugins.jacoco.version>
 
         <h2.version>2.3.232</h2.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
@@ -93,6 +96,21 @@
         <jaxb.version>2.3.1</jaxb.version>
 
         <cpp.repo.name>maven-parent-pom</cpp.repo.name>
+
+        <!-- Jakarta/javax dependency versions used in plugin dependency blocks -->
+        <glassfish-json.version>2.0.1</glassfish-json.version>
+        <glassfish-javax-json.version>1.1.4</glassfish-javax-json.version>
+        <jackson-datatype-jakarta-jsonp.version>2.14.2</jackson-datatype-jakarta-jsonp.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
+        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <javax.persistence-api.version>2.2</javax.persistence-api.version>
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+        <jee.api.version>10.0.0</jee.api.version>
+        <parsson.version>1.1.0</parsson.version>
+        <persistence-api.version>3.1.0</persistence-api.version>
     </properties>
 
     <scm>
@@ -131,21 +149,6 @@
         </plugins>
     </reporting>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.liquibase</groupId>
-                <artifactId>liquibase-core</artifactId>
-                <version>${liquibase.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <resources>
             <resource>
@@ -179,6 +182,7 @@
                     <version>${plugins.maven.surefire.version}</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
+                        <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
                     </configuration>
                 </plugin>
 
@@ -392,7 +396,7 @@
                     <artifactId>maven-war-plugin</artifactId>
                     <version>${plugins.maven.war.version}</version>
                     <configuration>
-                        <packagingExcludes>WEB-INF/web.xml</packagingExcludes>
+                        <packagingExcludes>WEB-INF/web.xml,WEB-INF/lib/resteasy-*.jar</packagingExcludes>
                         <!-- Java EE 7 doesn't require web.xml, Maven needs to catch up! -->
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                         <archive>
@@ -486,8 +490,8 @@
                     <version>${plugins.coveralls.version}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
                             <version>${jaxb.version}</version>
                         </dependency>
                     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>21.0.0-M1</version>
     </parent>
 
     <artifactId>maven-parent-pom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
## Summary
Upgrades `cp-maven-parent-pom` to Java 21 as part of the Framework E (17.104.x) release line backport of the Java 21 / WildFly 32 / Jakarta EE 10 upgrade.

## Related
Framework E docs and status: https://github.com/hmcts/java-21-wildfly-32-updgrade-pilot-cpp-framework