### PR TITLE
Upgrade maven-compiler-plugin from 3.10.1 to 3.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
         <plugins.maven.assembly.version>3.0.0</plugins.maven.assembly.version>
         <plugins.maven.clean.version>3.0.0</plugins.maven.clean.version>
-        <plugins.maven.compiler.version>3.10.1</plugins.maven.compiler.version>
+        <plugins.maven.compiler.version>3.15.0</plugins.maven.compiler.version>
         <plugins.maven.dependency.version>3.0.1</plugins.maven.dependency.version>
         <plugins.maven.deploy.version>2.8.2</plugins.maven.deploy.version>
         <plugins.maven.install.version>2.5.2</plugins.maven.install.version>


### PR DESCRIPTION
## Summary
- Upgrade `maven-compiler-plugin` from `3.10.1` to `3.15.0` as part of the Java 25 / WildFly 40 milestone upgrade chain
- Version property `plugins.maven.compiler.version` updated in root pom

## Test plan
- [ ] Downstream builds (`cp-maven-common-bom`, `cp-framework-libraries`, etc.) compile and test cleanly against this version